### PR TITLE
Make prebuilt shared library available

### DIFF
--- a/prometheus/nginx-exporter.json
+++ b/prometheus/nginx-exporter.json
@@ -1,0 +1,8 @@
+[
+    {
+      "targets": [ "localhost"],
+      "labels": {
+        "<labelname>": "<labelvalue>"
+      }
+    }
+  ]

--- a/setup-nginx.sh
+++ b/setup-nginx.sh
@@ -1,0 +1,13 @@
+# Setup a build directory
+
+cd ~/nginx-exporter
+
+# copy the vhost_traffic_status module 
+sudo cp ~/nginx-exporter/ngx_http_vhost_traffic_status_module.so /etc/nginx/modules/ngx_http_vhost_traffic_status_module.so
+
+# copy the nginx configuration
+sudo cp ~/nginx-exporter/conf.d/vhost_traffic_status.module /etc/nginx/conf.d/vhost_traffic_status.module
+sudo cp ~/nginx-exporter/conf.d/vhost_traffic_status.conf /etc/nginx/conf.d/vhost_traffic_status.conf
+
+# Restart nginx 
+sudo nginx -s reload

--- a/upgrade-nginx.sh
+++ b/upgrade-nginx.sh
@@ -1,0 +1,49 @@
+# Setup a build directory
+
+mkdir ~/nginx-build && cd ~/nginx-build
+
+# Backup nginx config files
+
+BACKUP_DIR = /etc/nginx-backup`date -I`
+
+sudo mkdir $BACKUP_DIR
+sudo cp -r /etc/nginx/* $BACKUP_DIR
+
+# Note down nginx version and details
+
+nginx -V
+
+# Install  utils to manage apt sources
+
+sudo apt install software-properties-common
+
+# Add nginx package signing key
+
+wget http://nginx.org/keys/nginx_signing.key
+sudo apt-key add nginx_signing.key
+
+# Add nginx package sources
+
+. /etc/os-release
+sudo add-apt-repository 'deb http://nginx.org/packages/mainline/ubuntu/ $UBUNTU_CODENAME nginx'
+
+# Stop nginx
+
+sudo service nginx stop
+
+# Update and install nginx
+
+sudo apt update
+sudo apt install ngnix 
+## Select 'N' (No) for overwrite /etc/nginx/nginx.conf
+
+# Start nginx 
+
+sudo service nginx start
+
+# Verify latest nginx version 
+
+nginx -V
+
+
+


### PR DESCRIPTION
- Added an precompiled shared library build against nginx v1.12.2 stable from http://nginx.org/packages/mainline/ubuntu/

References:

- Ngix Deb Package: "http://nginx.org/packages/mainline/ubuntu/ xenial nginx"
- Nginx Source: http://nginx.org/download/nginx-1.12.2.tar.gz
- Nginx Module VTS: https://github.com/vozlt/nginx-module-vts.git Version: v0.1.15